### PR TITLE
Handle php-64bit requirement

### DIFF
--- a/src/main/Monorepo/Build.php
+++ b/src/main/Monorepo/Build.php
@@ -148,7 +148,11 @@ class Build
 
         foreach ($dependencies as $dependencyName) {
             $isVendor = (strpos($dependencyName, $vendorDir) === 0);
-            if ($dependencyName === $vendorDir . '/php' || strpos($dependencyName, $vendorDir . '/ext-') === 0 || strpos($dependencyName, $vendorDir . '/lib-') === 0) {
+            if ($dependencyName === $vendorDir . '/php'
+                || $dependencyName === $vendorDir.'/php-64bit'
+                || strpos($dependencyName, $vendorDir . '/ext-') === 0
+                || strpos($dependencyName, $vendorDir . '/lib-') === 0
+                ) {
                 continue; // Meta-dependencies that composer checks
             }
 


### PR DESCRIPTION
composer supports `php-64bit` besides `php` as requirement (https://github.com/composer/composer/issues/7914).
This PR adds support to handle this case